### PR TITLE
Make tests pass on pypy3 by skipping casefold

### DIFF
--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -136,7 +136,8 @@ def test_py3():
         return
     value = Color('{red}this is a test.{/red}')
 
-    assert '\033[31mss\033[39m' == Color('{red}ß{/red}').casefold()
+    if hasattr(Color, 'casefold'):
+        assert '\033[31mss\033[39m' == Color('{red}ß{/red}').casefold()
 
     actual = Color('{red}{name} was born in {country}{/red}').format_map(Default(name='Guido'))
     assert '\033[31mGuido was born in country\033[39m' == actual

--- a/tests/test_no_colors.py
+++ b/tests/test_no_colors.py
@@ -126,7 +126,9 @@ def test_py3():
     #assert '' == Color(b'', 'latin-1')  bytes has no .format().
     #assert 'abc' == Color(b'\x80abc', errors='ignore')
 
-    assert 'ss' == Color('ß').casefold()
+    if hasattr(Color, 'casefold'):
+        assert 'ss' == Color('ß').casefold()
+
     assert 'Guido was born in country' == Color('{name} was born in {country}').format_map(Default(name='Guido'))
 
     assert Color('var').isidentifier()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34
+envlist = py26, py27, pypy, pypy3, py33, py34
 
 [testenv]
 deps =


### PR DESCRIPTION
```
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  pypy3: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```