### PR TITLE
tox.ini: Add flake8 target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,19 @@
 [tox]
 envlist = py26, py27, pypy, py33, py34
 
+[flake8]
+max-line-length = 128
+exclude = .tox,.git
+
 [testenv]
 deps =
     pytest
     pytest-cov
 commands = py.test {posargs:-v --cov=colorclass --cov-report=term-missing}
+
+[testenv:flake8]
+deps =
+    flake8
+    pep8-naming
+commands =
+    flake8


### PR DESCRIPTION
    $ tox -e flake8
    GLOB sdist-make: /Users/marca/dev/git-repos/colorclass/setup.py
    flake8 inst-nodeps: /Users/marca/dev/git-repos/colorclass/.tox/dist/colorclass-1.1.2.zip
    flake8 runtests: PYTHONHASHSEED='3780309638'
    flake8 runtests: commands[0] | flake8
    ./tests/test_windows.py:38:5: E265 block comment should start with '# '
    ./tests/test_no_colors.py:39:5: E731 do not assign a lambda expression, use a def
    ./tests/test_no_colors.py:126:5: E265 block comment should start with '# '
    ./tests/test_no_colors.py:127:5: E265 block comment should start with '# '
    ./tests/test_colors.py:41:5: E731 do not assign a lambda expression, use a def
    ERROR: InvocationError: '/Users/marca/dev/git-repos/colorclass/.tox/flake8/bin/flake8'
    ___________________________________________________________________________________ summary ____________________________________________________________________________________
    ERROR:   flake8: commands failed