### PR TITLE
replace colorclass.* absolute imports by relative imports

### DIFF
--- a/colorclass/__init__.py
+++ b/colorclass/__init__.py
@@ -8,16 +8,16 @@ https://github.com/Robpol86/colorclass
 https://pypi.python.org/pypi/colorclass
 """
 
-from colorclass.codes import list_tags  # noqa
-from colorclass.color import Color  # noqa
-from colorclass.toggles import disable_all_colors  # noqa
-from colorclass.toggles import disable_if_no_tty  # noqa
-from colorclass.toggles import enable_all_colors  # noqa
-from colorclass.toggles import is_enabled  # noqa
-from colorclass.toggles import is_light  # noqa
-from colorclass.toggles import set_dark_background  # noqa
-from colorclass.toggles import set_light_background  # noqa
-from colorclass.windows import Windows  # noqa
+from .codes import list_tags  # noqa
+from .color import Color  # noqa
+from .toggles import disable_all_colors  # noqa
+from .toggles import disable_if_no_tty  # noqa
+from .toggles import enable_all_colors  # noqa
+from .toggles import is_enabled  # noqa
+from .toggles import is_light  # noqa
+from .toggles import set_dark_background  # noqa
+from .toggles import set_light_background  # noqa
+from .windows import Windows  # noqa
 
 
 __all__ = (

--- a/colorclass/__main__.py
+++ b/colorclass/__main__.py
@@ -9,12 +9,12 @@ from __future__ import print_function
 import fileinput
 import os
 
-from colorclass.color import Color
-from colorclass.toggles import disable_all_colors
-from colorclass.toggles import enable_all_colors
-from colorclass.toggles import set_dark_background
-from colorclass.toggles import set_light_background
-from colorclass.windows import Windows
+from .color import Color
+from .toggles import disable_all_colors
+from .toggles import enable_all_colors
+from .toggles import set_dark_background
+from .toggles import set_light_background
+from .windows import Windows
 
 TRUTHY = ('true', '1', 'yes', 'on')
 

--- a/colorclass/color.py
+++ b/colorclass/color.py
@@ -1,6 +1,6 @@
 """Color class used by library users."""
 
-from colorclass.core import ColorStr
+from .core import ColorStr
 
 
 class Color(ColorStr):

--- a/colorclass/core.py
+++ b/colorclass/core.py
@@ -1,8 +1,8 @@
 """String subclass that handles ANSI color codes."""
 
-from colorclass.codes import ANSICodeMapping
-from colorclass.parse import parse_input, RE_SPLIT
-from colorclass.search import build_color_index, find_char_color
+from .codes import ANSICodeMapping
+from .parse import parse_input, RE_SPLIT
+from .search import build_color_index, find_char_color
 
 PARENT_CLASS = type(u'')
 

--- a/colorclass/parse.py
+++ b/colorclass/parse.py
@@ -2,7 +2,7 @@
 
 import re
 
-from colorclass.codes import ANSICodeMapping, BASE_CODES
+from .codes import ANSICodeMapping, BASE_CODES
 
 CODE_GROUPS = (
     tuple(set(str(i) for i in BASE_CODES.values() if i and (40 <= i <= 49 or 100 <= i <= 109))),  # bg colors

--- a/colorclass/search.py
+++ b/colorclass/search.py
@@ -1,6 +1,6 @@
 """Determine color of characters that may or may not be adjacent to ANSI escape sequences."""
 
-from colorclass.parse import RE_SPLIT
+from .parse import RE_SPLIT
 
 
 def build_color_index(ansi_string):

--- a/colorclass/toggles.py
+++ b/colorclass/toggles.py
@@ -1,6 +1,6 @@
 """Convenience functions to enable/disable features."""
 
-from colorclass.codes import ANSICodeMapping
+from .codes import ANSICodeMapping
 
 
 def disable_all_colors():

--- a/colorclass/windows.py
+++ b/colorclass/windows.py
@@ -7,8 +7,8 @@ import ctypes
 import re
 import sys
 
-from colorclass.codes import ANSICodeMapping, BASE_CODES
-from colorclass.core import RE_SPLIT
+from .codes import ANSICodeMapping, BASE_CODES
+from .core import RE_SPLIT
 
 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 INVALID_HANDLE_VALUE = -1


### PR DESCRIPTION
Hello,

I am using colorclass in my project [oletools](https://github.com/decalage2/oletools). I have included colorclass in a subfolder, rather than relying on the user to install it separately with pip. 

It works well, except with MacOSX: because the colorclass modules import each other using absolute imports (for example "from **colorclass.**codes import list_tags"), Python 2.7 on MacOSX does not find the modules. 

In this pull request, I have changed the absolute imports to relative imports (for example "from **.**codes import list_tags"), so that it works wherever colorclass is installed. It works fine with Python 2.7 on MacOSX and Ubuntu. I have not tested other platforms.