### PR TITLE
Make code forwards-compatible with Python 3.9

### DIFF
--- a/colorclass/codes.py
+++ b/colorclass/codes.py
@@ -1,7 +1,12 @@
 """Handles mapping between color names and ANSI codes and determining auto color codes."""
 
 import sys
-from collections import Mapping
+try:
+    # Using or importing the ABCs from 'collections' instead of from 'collections.abc' is 
+    # deprecated since Python 3.3, and in 3.9 it will stop working
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 BASE_CODES = {
     '/all': 0, 'b': 1, 'f': 2, 'i': 3, 'u': 4, 'flash': 5, 'outline': 6, 'negative': 7, 'invis': 8, 'strike': 9,


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working